### PR TITLE
Suggest changes for PR #714

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -163,7 +163,7 @@ nest::ConnectionManager::get_synapse_status( index gid,
 
   DictionaryDatum dict( new Dictionary );
   validate_pointer( connections_[ tid ].get( gid ) )
-    ->get_synapse_status( syn_id, dict, p );
+    ->get_synapse_status( syn_id, dict, p, tid );
   ( *dict )[ names::source ] = gid;
   ( *dict )[ names::synapse_model ] = LiteralDatum(
     kernel().model_manager.get_synapse_prototype( syn_id ).get_name() );

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -135,8 +135,10 @@ class ConnectorBase
 public:
   ConnectorBase();
 
-  virtual void
-  get_synapse_status( synindex syn_id, DictionaryDatum& d, port p ) const = 0;
+  virtual void get_synapse_status( synindex syn_id,
+    DictionaryDatum& d,
+    port p,
+    const thread tid ) const = 0;
   virtual void set_synapse_status( synindex syn_id,
     ConnectorModel& cm,
     const DictionaryDatum& d,
@@ -300,12 +302,17 @@ public:
   }
 
   void
-  get_synapse_status( synindex syn_id, DictionaryDatum& d, port p ) const
+  get_synapse_status( synindex syn_id,
+    DictionaryDatum& d,
+    port p,
+    const thread tid ) const
   {
     if ( syn_id == C_[ 0 ].get_syn_id() )
     {
       assert( p >= 0 && static_cast< size_t >( p ) < K );
       C_[ p ].get_status( d );
+      // set target gid here, where tid is available
+      def< long >( d, names::target, C_[ p ].get_target( tid )->get_gid() );
     }
   }
 
@@ -583,12 +590,17 @@ public:
   }
 
   void
-  get_synapse_status( synindex syn_id, DictionaryDatum& d, port p ) const
+  get_synapse_status( synindex syn_id,
+    DictionaryDatum& d,
+    port p,
+    const thread tid ) const
   {
     if ( syn_id == C_[ 0 ].get_syn_id() )
     {
       assert( static_cast< size_t >( p ) == 0 );
       C_[ 0 ].get_status( d );
+      // set target gid here, where tid is available
+      def< long >( d, names::target, C_[ 0 ].get_target( tid )->get_gid() );
     }
   }
 
@@ -834,12 +846,17 @@ public:
   }
 
   void
-  get_synapse_status( synindex syn_id, DictionaryDatum& d, port p ) const
+  get_synapse_status( synindex syn_id,
+    DictionaryDatum& d,
+    port p,
+    const thread tid ) const
   {
     if ( syn_id == C_[ 0 ].get_syn_id() )
     {
       assert( p >= 0 && static_cast< size_t >( p ) < C_.size() );
       C_[ p ].get_status( d );
+      // set target gid here, where tid is available
+      def< long >( d, names::target, C_[ p ].get_target( tid )->get_gid() );
     }
   }
 
@@ -1080,11 +1097,14 @@ public:
   }
 
   void
-  get_synapse_status( synindex syn_id, DictionaryDatum& d, port p ) const
+  get_synapse_status( synindex syn_id,
+    DictionaryDatum& d,
+    port p,
+    const thread tid ) const
   {
     for ( size_t i = 0; i < size(); i++ )
     {
-      at( i )->get_synapse_status( syn_id, d, p );
+      at( i )->get_synapse_status( syn_id, d, p, tid );
     }
   }
 


### PR DESCRIPTION
It would be possible to set the target gid outside of `get_status` of the connection, for example, in the `get_synapse_status` of the different Connectors. It's a work-around that allows keeping the `set_status` signature.